### PR TITLE
Add simple doctest-based unit test for cmake example

### DIFF
--- a/examples/cmake/CMakeLists.txt
+++ b/examples/cmake/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.12)
+project(essl_strip_demo CXX)
+
+find_program(RE2C_EXECUTABLE NAMES re2c REQUIRED)
+
+set(GENERATED ${CMAKE_CURRENT_BINARY_DIR}/essl_strip.cpp)
+add_custom_command(
+    OUTPUT ${GENERATED}
+    COMMAND ${RE2C_EXECUTABLE} -c -i -o ${GENERATED} ${CMAKE_CURRENT_SOURCE_DIR}/essl_strip.re
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/essl_strip.re
+    VERBATIM)
+
+add_library(essl_strip ${GENERATED})
+target_include_directories(essl_strip PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(essl_strip_demo main.cpp)
+target_link_libraries(essl_strip_demo essl_strip)
+
+add_executable(essl_strip_tests tests.cpp)
+target_link_libraries(essl_strip_tests essl_strip)
+
+enable_testing()
+add_test(NAME essl_strip_tests COMMAND essl_strip_tests)

--- a/examples/cmake/README.md
+++ b/examples/cmake/README.md
@@ -1,0 +1,10 @@
+This example shows how to integrate re2c with CMake.
+
+Build the `essl_strip_demo` executable by pointing CMake to a re2c binary:
+
+```bash
+cmake -B build -DRE2C_EXECUTABLE=/path/to/re2c
+cmake --build build
+```
+
+Running the executable prints the stripped shader source.

--- a/examples/cmake/doctest.h
+++ b/examples/cmake/doctest.h
@@ -1,0 +1,30 @@
+#ifndef DOCTEST_H
+#define DOCTEST_H
+#include <vector>
+#include <functional>
+#include <stdexcept>
+#include <iostream>
+
+struct doctest_test {
+    const char* name;
+    void (*func)();
+};
+inline std::vector<doctest_test>& doctest_tests(){ static std::vector<doctest_test> v; return v; }
+struct doctest_reg { doctest_reg(const char* n, void(*f)()){ doctest_tests().push_back({n,f}); } };
+#define DOCTEST_TEST_CASE(name) \
+    static void name(); \
+    static doctest_reg reg_##name(#name,&name); \
+    static void name()
+
+#define DOCTEST_CHECK(expr) do{ if(!(expr)) { std::cerr<<"check failed: "<<#expr<<"\n"; throw std::runtime_error("check failed"); } }while(0)
+
+#ifdef DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+int main(){
+    for(auto& t: doctest_tests()){
+        try{ t.func(); }
+        catch(const std::exception& e){ std::cerr<<"Test "<<t.name<<" failed: "<<e.what()<<"\n"; return 1; }
+    }
+    return 0;
+}
+#endif
+#endif // DOCTEST_H

--- a/examples/cmake/essl_strip.h
+++ b/examples/cmake/essl_strip.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <string>
+
+void essl_strip(const char *s, std::string &out);

--- a/examples/cmake/essl_strip.re
+++ b/examples/cmake/essl_strip.re
@@ -1,0 +1,43 @@
+// re2c $INPUT -o $OUTPUT -c -i
+#include <string>
+
+/*!conditions:re2c*/
+#include "essl_strip.h"
+
+void essl_strip(const char *s, std::string &out) {
+    const char *YYCURSOR = s, *YYMARKER;
+    int c = yycINITIAL;
+    /*!re2c
+        re2c:api:style = free-form;
+        re2c:define:YYCTYPE   = char;
+        re2c:define:YYGETCONDITION = "c";
+        re2c:define:YYSETCONDITION = "c = @@;";
+        re2c:yyfill:enable    = 0;
+
+        Ws          = [ \t\r\n]+;
+        OptWs       = [ \t\r\n]*;
+        Any         = [\x00-\xFF];
+        Qual        = "lowp" | "mediump" | "highp";
+        Ident       = [a-zA-Z_][a-zA-Z0-9_]*;
+
+        V300        = "#version" Ws "300" Ws "es";
+        V310        = "#version" Ws "310" Ws "es";
+        V320        = "#version" Ws "320" Ws "es";
+        V100        = "#version" Ws "100";
+
+        <INITIAL> "\x00" { return; }
+        <INITIAL> V300    { out.append("#version 330 core\n"); goto yyc_CODE; }
+        <INITIAL> V310    { out.append("#version 430 core\n"); goto yyc_CODE; }
+        <INITIAL> V320    { out.append("#version 450 core\n"); goto yyc_CODE; }
+        <INITIAL> V100    { out.append("#version 100\n"); goto yyc_CODE100; }
+        <INITIAL> Any     { out.push_back(*YYCURSOR); }
+
+        <CODE> "\x00" { return; }
+        <CODE> "precision" Ws Qual Ws Ident OptWs ";"   { /* drop */ }
+        <CODE> Qual Ws                                { /* skip token */ }
+        <CODE> Any                                    { out.push_back(*YYCURSOR); }
+
+        <CODE100> "\x00" { return; }
+        <CODE100> Any     { out.push_back(*YYCURSOR); }
+    */
+}

--- a/examples/cmake/main.cpp
+++ b/examples/cmake/main.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+#include <string>
+#include "essl_strip.h"
+
+int main() {
+    const char *shader =
+        "#version 310 es\n"
+        "precision mediump float;\n"
+        "mediump vec4 color;\n";
+
+    std::string out;
+    essl_strip(shader, out);
+    std::cout << out;
+    return 0;
+}

--- a/examples/cmake/tests.cpp
+++ b/examples/cmake/tests.cpp
@@ -1,0 +1,18 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "doctest.h"
+#include "essl_strip.h"
+#include <string>
+
+DOCTEST_TEST_CASE(test_strip_310) {
+    const char *shader = "#version 310 es\nprecision mediump float;\nmediump vec4 color;";
+    std::string out;
+    essl_strip(shader, out);
+    DOCTEST_CHECK(out == "#version 430 core\nvec4 color;");
+}
+
+DOCTEST_TEST_CASE(test_strip_100) {
+    const char *shader = "#version 100\nprecision mediump float;\nmediump vec4 color;";
+    std::string out;
+    essl_strip(shader, out);
+    DOCTEST_CHECK(out == "#version 100\nprecision mediump float;\nmediump vec4 color;");
+}


### PR DESCRIPTION
## Summary
- add minimal doctest header for unit testing
- create simple tests for the `essl_strip` example
- extend `examples/cmake` CMakeLists to build/run the tests

## Testing
- `cmake -S . -B build -DRE2C_EXECUTABLE=re2c` *(fails: re2c binary missing)*
- `cmake --build build -j$(nproc)` *(fails: essl_strip.cpp not generated)*

------
https://chatgpt.com/codex/tasks/task_e_684071116e3483208dfde62ccf1b800c